### PR TITLE
Cleanups using HA's ruff config

### DIFF
--- a/custom_components/ithodaalderop/__init__.py
+++ b/custom_components/ithodaalderop/__init__.py
@@ -1,3 +1,4 @@
+"""Init package."""
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant

--- a/custom_components/ithodaalderop/binary_sensor.py
+++ b/custom_components/ithodaalderop/binary_sensor.py
@@ -58,6 +58,7 @@ class IthoBinarySensor(BinarySensorEntity):
             return self.entity_description.icon_off
         if self.entity_description.icon is not None:
             return self.entity_description.icon
+        return None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""

--- a/custom_components/ithodaalderop/binary_sensor.py
+++ b/custom_components/ithodaalderop/binary_sensor.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""
-Binary Sensor component for Itho
+"""Binary Sensor component for Itho.
+
 Author: Benjamin
 """
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+import json
+
 from homeassistant.components import mqtt
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-import json
-from .const import CONF_CVE_TYPE,AddOnType,ADDONS
+from .const import ADDONS, CONF_CVE_TYPE, AddOnType
 from .definitions import NONCVEBINARYSENSORS, IthoBinarySensorEntityDescription
 
 
@@ -43,19 +43,20 @@ class IthoBinarySensor(BinarySensorEntity):
 
     @property
     def name(self):
+        """Name for the binary sensor."""
         return self.entity_description.translation_key.replace("_", " ").capitalize()
 
     @property
     def icon(self):
+        """Icon for binary sensor."""
         if (
             self.entity_description.icon_off is not None
             and self.entity_description.icon_on is not None
         ):
             if self._attr_is_on:
                 return self.entity_description.icon_on
-            else:
-                return self.entity_description.icon_off
-        elif self.entity_description.icon is not None:
+            return self.entity_description.icon_off
+        if self.entity_description.icon is not None:
             return self.entity_description.icon
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/ithodaalderop/const.py
+++ b/custom_components/ithodaalderop/const.py
@@ -1,3 +1,5 @@
+"""Consts for Itho add-on."""
+
 import logging
 from enum import IntEnum
 
@@ -5,6 +7,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class AddOnType(IntEnum):
+    """Enum for Add-on types."""
+
     CVE = 1
     WPU = 2
     AUTOTEMP = 3

--- a/custom_components/ithodaalderop/definitions.py
+++ b/custom_components/ithodaalderop/definitions.py
@@ -5,23 +5,23 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntityDescription,
+)
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntityDescription,
-    SensorStateClass
-)
-from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
-    BinarySensorEntityDescription
+    SensorStateClass,
 )
 from homeassistant.const import (
-    UnitOfTemperature,
-    UnitOfTime,
+    CONCENTRATION_PARTS_PER_MILLION,
+    PERCENTAGE,
+    REVOLUTIONS_PER_MINUTE,
     UnitOfPower,
     UnitOfPressure,
-    CONCENTRATION_PARTS_PER_MILLION,
-    REVOLUTIONS_PER_MINUTE,
-    PERCENTAGE
+    UnitOfTemperature,
+    UnitOfTime,
 )
 
 from .const import MQTT_STATETOPIC

--- a/custom_components/ithodaalderop/sensor.py
+++ b/custom_components/ithodaalderop/sensor.py
@@ -147,6 +147,7 @@ class IthoSensor(SensorEntity):
             return {
                 "Error Description": self._rh_error_description,
             }
+        return None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""

--- a/custom_components/ithodaalderop/sensor.py
+++ b/custom_components/ithodaalderop/sensor.py
@@ -1,31 +1,45 @@
 #!/usr/bin/env python3
+"""Sensor component for Itho WiFi addon.
+
+Author: Jasper
 """
-Sensor component for Itho
-Author: Jasper Slits
-"""
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.components import mqtt
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.core import HomeAssistant, callback
 
 import copy
-from datetime import datetime, timedelta
 import json
+from datetime import datetime, timedelta
 
-from .const import *
-from .const import _LOGGER
+from homeassistant.components import mqtt
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    _LOGGER,
+    ADDONS,
+    CONF_CVE_TYPE,
+    CONF_USE_AUTOTEMP,
+    CONF_USE_REMOTES,
+    CONF_USE_WPU,
+    HRU_ACTUAL_MODE,
+    HRU_GLOBAL_FAULT_CODE,
+    MQTT_STATETOPIC,
+    RH_ERROR_CODE,
+    UNITTYPE_ICONS,
+    WPU_STATUS,
+    AddOnType,
+)
 from .definitions import (
+    AUTOTEMPSENSORS,
     CVESENSORS,
     NONCVESENSORS,
     WPUSENSORS,
-    AUTOTEMPSENSORS,
     IthoSensorEntityDescription,
 )
 
 
 def _create_remotes(config_entry: ConfigEntry):
+    """Create remotes for CO2 monitoring."""
 
     cfg = config_entry.data
     REMOTES = []
@@ -43,6 +57,8 @@ def _create_remotes(config_entry: ConfigEntry):
 
 
 def _create_autotemprooms(config_entry: ConfigEntry):
+    """Create autotemp rooms for configured entries."""
+
     cfg = config_entry.data
     configured_sensors = []
     for x in range(1, 8):
@@ -98,18 +114,22 @@ class IthoSensor(SensorEntity):
         self.aot = aot
 
     @property
-    def name(self):
+    def name(self) -> str:
+        """Generate name for the sensor."""
         return self.entity_description.translation_key.replace("_", " ").capitalize()
 
     @property
-    def icon(self):
+    def icon(self) -> str|None:
+        """Pick the right icon."""
+
         if self.entity_description.icon is not None:
             return self.entity_description.icon
-        elif self.entity_description.native_unit_of_measurement in UNITTYPE_ICONS:
+        if self.entity_description.native_unit_of_measurement in UNITTYPE_ICONS:
             return UNITTYPE_ICONS[self.entity_description.native_unit_of_measurement]
+        return None
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> []|None:
         """Return the state attributes."""
 
         if self._global_fault_code_description is not None:
@@ -152,7 +172,7 @@ class IthoSensor(SensorEntity):
                             try:
                                 self._filter_last_maintenance = (datetime.now() - timedelta(hours=int(value))).date()
                                 self._filter_next_maintenance_estimate = (datetime.now() + timedelta(days=180, hours=-int(value))).date()
-                            except Exceptio as e:
+                            except ValueError as e:
                                 _LOGGER.error(f"failed to parse value for 'Airfilter counter'\n{e}")
 
                         if self.entity_description.json_field == "Global fault code":

--- a/custom_components/ithodaalderop/sensor.py
+++ b/custom_components/ithodaalderop/sensor.py
@@ -129,7 +129,7 @@ class IthoSensor(SensorEntity):
         return None
 
     @property
-    def extra_state_attributes(self) -> []|None:
+    def extra_state_attributes(self) -> list[str]|None:
         """Return the state attributes."""
 
         if self._global_fault_code_description is not None:


### PR DESCRIPTION
Using ruff's config of HA, addressed some errors. Not sure if this should be suppressed or "fixed"

```
custom_components/ithodaalderop/binary_sensor.py:59:9: RET503 Missing explicit `return` at the end of function able to return non-`None` value
   |
57 |                   return self.entity_description.icon_on
58 |               return self.entity_description.icon_off
59 |           if self.entity_description.icon is not None:
   |  _________^
60 | |             return self.entity_description.icon
   | |_______________________________________________^ RET503
61 |   
62 |       async def async_added_to_hass(self) -> None:
   |
   = help: Add explicit `return` statement

custom_components/ithodaalderop/sensor.py:146:9: RET503 Missing explicit `return` at the end of function able to return non-`None` value
    |
144 |               }
145 |   
146 |           if self._rh_error_description is not None:
    |  _________^
147 | |             return {
148 | |                 "Error Description": self._rh_error_description,
149 | |             }
    | |_____________^ RET503
150 |   
151 |       async def async_added_to_hass(self) -> None:
    |
    = help: Add explicit `return` statement
```