### PR TITLE
Create a new device per add-on and link entities

### DIFF
--- a/custom_components/ithodaalderop/config_flow.py
+++ b/custom_components/ithodaalderop/config_flow.py
@@ -126,7 +126,7 @@ class IthoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Configure main step."""
         if info is not None:
             self.config.update(info)
-            if info[CONF_ADDON_TYPE] == "cve" or info[CONF_ADDON_TYPE] == "noncve":
+            if info[CONF_ADDON_TYPE] in ["cve","noncve"]:
                 return await self.async_step_remotes()
             if info[CONF_ADDON_TYPE] == "autotemp":
                 return await self.async_step_rooms()
@@ -157,7 +157,7 @@ class IthoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         assert entry
         self.entry = entry
         self.config.update(entry.data)
-        if self.config[CONF_ADDON_TYPE] == "cve" or self.config[CONF_ADDON_TYPE] == "noncve" :
+        if self.config[CONF_ADDON_TYPE]  in ["cve","noncve"]:
                 return await self.async_step_remotes_reconfigure()
         if self.config[CONF_ADDON_TYPE] == "autotemp":
                 return await self.async_step_rooms_reconfigure()

--- a/custom_components/ithodaalderop/const.py
+++ b/custom_components/ithodaalderop/const.py
@@ -18,7 +18,7 @@ class AddOnType(IntEnum):
 ADDON_TYPES = {
     "noncve": "HRU WTW",
     "cve": "CVE",
-    "autotemp": "Autotemp",
+    "autotemp": "Autotemp floor heating",
     "wpu": "WPU heatpump"
 }
 
@@ -81,7 +81,6 @@ CVE_TYPES = {
     "cve": ["cve", "mdi:fan"],
 }
 
-
 UNITTYPE_ICONS = {
     "%": "mdi:percent-outline",
     "hum": "mdi:water-percent",
@@ -96,6 +95,7 @@ MQTT_BASETOPIC = {
     "wpu": "ithowpu",
     "autotemp": "ithotemp",
 }
+
 MQTT_STATETOPIC = {
     "cve": "ithostatus",
     "noncve": "ithostatus",
@@ -103,7 +103,7 @@ MQTT_STATETOPIC = {
     "autotemp": "ithostatus",
     "remotes": "remotesinfo",
 }
-CONF_ENABLED_SENSORS = "ithohru/remotesinfo"
+
 CONF_ADDON_TYPE = "addontype"
 
 CONF_AUTOTEMP_ROOM1 = "room1"
@@ -120,4 +120,3 @@ CONF_REMOTE_2 = "remote2"
 CONF_REMOTE_3 = "remote3"
 CONF_REMOTE_4 = "remote4"
 CONF_REMOTE_5 = "remote5"
-CONF_REMOTE_6 = "remote6"

--- a/custom_components/ithodaalderop/sensor.py
+++ b/custom_components/ithodaalderop/sensor.py
@@ -60,10 +60,11 @@ def _create_autotemprooms(config_entry: ConfigEntry):
     cfg = config_entry.data
     configured_sensors = []
     for x in range(1, 8):
+        _LOGGER.warn("Range " + str(x))
         template_sensors = copy.deepcopy(list(AUTOTEMPSENSORS))
         room = cfg["room" + str(x)]
         if room != "" and room != "Room " + str(x):
-
+            _LOGGER.warn("Room " + str(x))
             for sensor in template_sensors:
                 sensor.key = f"{MQTT_BASETOPIC["autotemp"]}/{MQTT_STATETOPIC["autotemp"]}"
                 sensor.json_field = sensor.json_field.replace("X", str(x))
@@ -94,12 +95,16 @@ async def async_setup_entry(
             description.key = f"{MQTT_BASETOPIC["cve"]}/{MQTT_STATETOPIC["cve"]}"
             sensors.append(IthoSensor(description, config_entry, AddOnType.CVE))
 
-        (sensors.append(IthoSensor(description, config_entry, AddOnType.REMOTES)) for description in _create_remotes(config_entry))
+    if config_entry.data[CONF_ADDON_TYPE] in ["cve","noncve"]:
+            sensors.append(IthoSensor(description, config_entry, AddOnType.REMOTES) for description in _create_remotes(config_entry))
 
     if config_entry.data[CONF_ADDON_TYPE] == "wpu":
         for description in WPUSENSORS:
             description.key = f"{MQTT_BASETOPIC["wpu"]}/{MQTT_STATETOPIC["wpu"]}"
             sensors.append(IthoSensor(description, config_entry, AddOnType.WPU))
+
+    if config_entry.data[CONF_ADDON_TYPE] == "autotemp":
+        sensors.append(IthoSensor(description, config_entry, AddOnType.AUTOTEMP) for description in _create_autotemprooms(config_entry))
 
     async_add_entities(sensors)
 

--- a/custom_components/ithodaalderop/sensor.py
+++ b/custom_components/ithodaalderop/sensor.py
@@ -12,12 +12,14 @@ from homeassistant.components import mqtt
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     _LOGGER,
     ADDONS,
     CONF_ADDON_TYPE,
+    DOMAIN,
     HRU_ACTUAL_MODE,
     HRU_GLOBAL_FAULT_CODE,
     MQTT_BASETOPIC,
@@ -60,11 +62,9 @@ def _create_autotemprooms(config_entry: ConfigEntry):
     cfg = config_entry.data
     configured_sensors = []
     for x in range(1, 8):
-        _LOGGER.warn("Range " + str(x))
         template_sensors = copy.deepcopy(list(AUTOTEMPSENSORS))
         room = cfg["room" + str(x)]
         if room != "" and room != "Room " + str(x):
-            _LOGGER.warn("Room " + str(x))
             for sensor in template_sensors:
                 sensor.key = f"{MQTT_BASETOPIC["autotemp"]}/{MQTT_STATETOPIC["autotemp"]}"
                 sensor.json_field = sensor.json_field.replace("X", str(x))
@@ -124,6 +124,13 @@ class IthoSensor(SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         self.entity_description = description
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, ADDONS[aot])},
+            manufacturer = "Arjen Hiemstra",
+            model = "CVE" if aot == AddOnType.CVE else "NONCVE",
+            name="Itho WiFi-Addon - " + ADDONS[aot]
+        )
 
         self.entity_id = f"sensor.{ADDONS[aot].lower()}_{description.translation_key}"
         self._attr_unique_id = f"{config_entry.entry_id}-{description.translation_key}"

--- a/custom_components/ithodaalderop/translations/en.json
+++ b/custom_components/ithodaalderop/translations/en.json
@@ -94,21 +94,21 @@
         "step": {
             "user": {
                 "title": "Add new Itho devices",
-                "description": "Select the devices you want to configure. Repeat the configuration for every physical add-on present.",
+                "description": "Select the devices you want to configure. Repeat the configuration for every physical add-on present. This integration creates commonly used sensors for each device.",
                 "data": {
-                    "addontype": "Type of add-on to configure"
+                    "addontype": "Select the type of add-on to configure."
                 }
             },
             "reconfigure": {
                 "title": "Reconfigure Itho devices",
                 "description": "Select the devices you want to reconfigure. Repeat the configuration for every physical add-on present.",
                 "data": {
-                    "addontype": "Type of add-on to reconfigure"
+                    "addontype": "Select the type of add-on to reconfigure."
                 }
             },
             "remotes": {
                 "title": "Add new Itho remotes",
-                "description": "Enter the names of the remotes as defined in the 'RF devices' menu item or press 'Submit' to skip",
+                "description": "Enter the names of the remotes as defined in the 'RF devices' menu item or press 'Submit' to skip.",
                 "data": {
                     "remote1": "Remote 1",
                     "remote2": "Remote 2",
@@ -119,7 +119,7 @@
             },
             "remotes_reconfigure": {
                 "title": "Reconfigure Itho remotes",
-                "description": "Enter the names of the remotes as defined in the 'RF devices' menu item or press 'Submit' to skip",
+                "description": "Enter the names of the remotes as defined in the 'RF devices' menu item or press 'Submit' to skip.",
                 "data": {
                     "remote1": "Remote 1",
                     "remote2": "Remote 2",
@@ -130,7 +130,7 @@
             },
             "rooms": {
                 "title": "Add new autotemp rooms",
-                "description": "Provide a name for each room defined in the autotemp unit. E.g. living room",
+                "description": "Provide a name for each room defined in the autotemp unit. E.g. living room or bedroom.",
                 "data": {
                     "room1": "Room 1",
                     "room2": "Room 2",
@@ -144,7 +144,7 @@
             },
             "rooms_reconfigure": {
                 "title": "Reconfigure autotemp rooms",
-                "description": "Provide a name for each room defined in the autotemp unit. E.g. living room",
+                "description": "Provide a name for each room defined in the autotemp unit. E.g. living room or bedroom.",
                 "data": {
                     "room1": "Room 1",
                     "room2": "Room 2",

--- a/custom_components/ithodaalderop/translations/nl.json
+++ b/custom_components/ithodaalderop/translations/nl.json
@@ -94,18 +94,14 @@
         "step": {
             "user": {
                 "title": "Voeg nieuwe Itho apparaten toe",
-                "description": "Configuratie stappen voor Itho",
+                "description": "Configuratie stappen voor Itho. Herhaal deze configuratie voor iedere fysieke add-on die gebruikt wordt. Deze integratie maakt automatisch de meest gebruikelijke sensors aan.",
                 "data": {
-                    "id": "Huis id",
-                    "cvetype": "Ventilator type",
-                    "use_remotes": "CO2 afstandsbedieningen",
-                    "use_wpu": "WPU",
-                    "use_autotemp": "Auto temp"
+                    "addontype": "Add-on type"
                 }
             },
             "remotes": {
                 "title": "Voeg nieuwe Itho afstandsbedieningen toe",
-                "description": "Gebruik de namen zoals deze ook zijn geconfigureerd in de Add-on bij RF Devices",
+                "description": "Gebruik de namen zoals deze ook zijn geconfigureerd in de Add-on bij RF Devices. Klik op 'Verzenden' zonder iets te wijzigen om dit over te slaan.",
                 "data": {
                     "remote1": "Afstandsbediening 1",
                     "remote2": "Afstandsbediening 2",
@@ -116,7 +112,7 @@
             },
             "remotes_reconfigure": {
                 "title": "Wijzig Itho afstandsbedieningen",
-                "description": "Gebruik de namen zoals deze ook zijn geconfigureerd in de Add-on bij RF Devices",
+                "description": "Gebruik de namen zoals deze ook zijn geconfigureerd in de Add-on bij RF Devices. ",
                 "data": {
                     "remote1": "Afstandsbediening 1",
                     "remote2": "Afstandsbediening 2",
@@ -127,7 +123,7 @@
             },
             "rooms_reconfigure": {
                 "title": "Wijzig Itho ruimtes",
-                "description": "Benoem de ruimtes gekoppeld aan de Auto temp unit. Bijv. Woonkamer",
+                "description": "Benoem de ruimtes gekoppeld aan de Auto temp unit. Bijv. Woonkamer or slaapkamer ouders.",
                 "data": {
                     "room1": "Ruimte 1",
                     "room2": "Ruimte 2",


### PR DESCRIPTION
This adds a new device per add-on. 

The 'MQTT fan' is actually an entity and not a device. So this should be fine. It's missing the link to configuration and other parts (e.g. software version) but that's for a later moment. 