### PR TITLE
Update entity for stable Itho releases

### DIFF
--- a/custom_components/ithodaalderop/__init__.py
+++ b/custom_components/ithodaalderop/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import CONF_ADDON_TYPE, CONF_NONCVE_MODEL
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.UPDATE]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/ithodaalderop/update.py
+++ b/custom_components/ithodaalderop/update.py
@@ -1,0 +1,111 @@
+"""Update entity for Home Assistant."""
+
+from __future__ import annotations
+
+import json
+
+from homeassistant.components import mqtt
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    ADDON_TYPES,
+    CONF_ADDON_TYPE,
+    CONF_NONCVE_MODEL,
+    DOMAIN,
+    MANUFACTURER,
+    MQTT_BASETOPIC,
+    NONCVE_DEVICES,
+)
+
+UPDATE_DESCRIPTION = UpdateEntityDescription(
+    key="firmware",
+    device_class=UpdateDeviceClass.FIRMWARE,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """One update sensor per device."""
+
+    async_add_entities([IthoHAUpdate(UPDATE_DESCRIPTION, config_entry)])
+
+
+class IthoHAUpdate(UpdateEntity):
+    """Update entity for Itho addon."""
+
+    _installedversion = ""
+    _latestversion = ""
+    _mqttbase = ""
+
+    def __init__(
+        self,
+        entity_description: UpdateEntityDescription,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the sensor."""
+
+        self._mqttbase = MQTT_BASETOPIC[config_entry.data[CONF_ADDON_TYPE]]
+
+        model = ADDON_TYPES[config_entry.data[CONF_ADDON_TYPE]]
+        if config_entry.data[CONF_ADDON_TYPE] == "noncve":
+            model = model + " - " + NONCVE_DEVICES[config_entry.data[CONF_NONCVE_MODEL]]
+
+        self._attr_name = model
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, config_entry.data[CONF_ADDON_TYPE])},
+            manufacturer=MANUFACTURER,
+            model=model,
+            name=ADDON_TYPES[config_entry.data[CONF_ADDON_TYPE]],
+        )
+
+        self.entity_description = entity_description
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to MQTT events."""
+
+        @callback
+        def message_received(message):
+            """Handle new MQTT messages."""
+            payload = json.loads(message.payload)
+            self._installedversion = payload["add-on_fwversion"]
+            self._latestversion = payload["add-on_latest_fw"]
+            self.async_write_ha_state()
+
+        await mqtt.async_subscribe(
+            self.hass, f"{self._mqttbase}/deviceinfo", message_received, 1
+        )
+
+    @property
+    def installed_version(self) -> str | None:
+        """HA Itho version on the device."""
+        return self._installedversion
+
+    @property
+    def latest_version(self) -> str:
+        """HA Itho stable version."""
+        return self._latestversion
+
+    @property
+    def title(self) -> str:
+        """Return title for the update."""
+        return "Stable release of the Itho Wifi add-on only"
+
+    @property
+    def release_url(self) -> str:
+        """Returns Github Repo link."""
+        return (
+            "https://github.com/arjenhiemstra/ithowifi/releases/tag/Version-"
+            + self._latestversion
+        )


### PR DESCRIPTION
Requires 2.9.0+ firmware as it uses the deviceinfo MQTT topic which is not available with prior releases. 

This is an MVP as for now it's only tracking stable releases as having two Update entities per device would be a mess. I've found beta firmware to be unstable most of the time. 

I cannot yet link the user to the Itho device homepage as the IP-address is not sent so the link goes to the Github page. 

