### PR TITLE
add states for HRU ECO 250 300

### DIFF
--- a/custom_components/ithodaalderop/const.py
+++ b/custom_components/ithodaalderop/const.py
@@ -161,6 +161,9 @@ HRU_ECO_STATUS = {
     2: "Decelerate Supply fan",
     3: "Accelerate Exhaust fan",
     4: "Stop supply fan",
+    5: "Heat Recovery",
+    8: "Cooling Recovery",
+    9: "Summer Bypass",
 }
 
 WPU_STATUS = {


### PR DESCRIPTION
This adds the states for the HRU ECO 250 & 300 to the map of the HRU ECO hoping that they do not conflict across devices.

See #118 for details