### PR TITLE
Add states for HRU ECO 250 300 separate from HRU ECO

### DIFF
--- a/custom_components/ithodaalderop/const.py
+++ b/custom_components/ithodaalderop/const.py
@@ -163,6 +163,12 @@ HRU_ECO_STATUS = {
     4: "Stop supply fan",
 }
 
+HRU_ECO_250_300_STATUS = {
+    5: "Heat Recovery",
+    8: "Cooling Recovery",
+    9: "Summer Bypass",
+}
+
 WPU_STATUS = {
     0: "Init",
     1: "Off",

--- a/custom_components/ithodaalderop/sensors/fan.py
+++ b/custom_components/ithodaalderop/sensors/fan.py
@@ -97,6 +97,20 @@ def get_noncve_sensors(config_entry: ConfigEntry):
 class IthoSensorFan(IthoBaseSensor):
     """Representation of a Itho add-on sensor that is updated via MQTT."""
 
+    _non_cve_model = ""
+
+    def __init__(
+        self,
+        description: IthoBinarySensorEntityDescription,
+        config_entry: ConfigEntry,
+        use_base_sensor_device: bool = True,
+    ) -> None:
+        if config_entry.data[CONF_ADDON_TYPE] == "noncve":
+            self._non_cve_model = config_entry.data[CONF_NONCVE_MODEL]
+
+        super().__init__(description, config_entry, use_base_sensor_device)
+
+
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""
         await mqtt.async_subscribe(
@@ -195,7 +209,10 @@ class IthoSensorFan(IthoBaseSensor):
 
                 _description = "Unknown status"
                 if str(value).isnumeric():
-                    _description = HRU_ECO_STATUS.get(int(value), _description)
+                    if self._non_cve_model in ["hru_eco_250", "hru_eco_300"]:
+                        _description = HRU_ECO_250_300_STATUS.get(int(value), _description)                        
+                    else:
+                        _description = HRU_ECO_STATUS.get(int(value), _description)
                 value = _description
 
         self._attr_native_value = value


### PR DESCRIPTION
This PR adds the states for the HRU ECO 250 & 300 and separates them from the states of the HRU ECO.

This is done by saving the model in a class variable and switching on it during the callback.

It's been a while since I have done any programming, so I have no idea if this would be an acceptable way of doing it. Please let me know! 😉 

see #118 for more details