### PR TITLE
Add 'Heat Recovery (Frost)' for status code '6' to HRU_ECO_250_300

### DIFF
--- a/custom_components/ithodaalderop/const.py
+++ b/custom_components/ithodaalderop/const.py
@@ -165,6 +165,7 @@ HRU_ECO_STATUS = {
 
 HRU_ECO_250_300_STATUS = {
     5: "Heat Recovery",
+    6: "Heat Recovery (Frost)",
     8: "Cooling Recovery",
     9: "Summer Bypass",
 }


### PR DESCRIPTION
With the cold temperatures in NL lately I discovered a new status code `6` being emitted by my HRU ECO 300.

Hooking up the Itho Daalderop utility shows this status as `HR_Frost` (as opposed to`HR_Mass`, for the usual heat recovery). This status change seems to happen when the `Mixed outside air temperature` is equal to or below 1 °C. I'm assuming the unit's main goal is still doing heat recovery (since the status is still prefixed with HR) but presumably with some additional frost protection.

I've added the status to the corresponding object in const.py and decided to give it `Heat Recovery (Frost)` as a human readable name.

Kind regards,
Aron