### PR TITLE
Fixes compatibility with HA 2026.02 release due to changes of entity validation

### DIFF
--- a/custom_components/ithodaalderop/utils.py
+++ b/custom_components/ithodaalderop/utils.py
@@ -63,7 +63,7 @@ def get_device_name(config: dict[str, Any]) -> str:
 
 def get_default_entity_prefix(config: dict[str, Any]) -> str:
     """Get the default entity prefix."""
-    return f"itho_{ADDON_TYPES[config[CONF_ADDON_TYPE]]}".replace("-","-").lower()
+    return f"itho_{ADDON_TYPES[config[CONF_ADDON_TYPE]]}".replace("-","_").lower()
 
 
 def get_entity_prefix(config: dict[str, Any]) -> str:


### PR DESCRIPTION
Applies to non-CVE HRU only.

Documented in #138 