### PR TITLE
Fixes spaces in names for rooms and co2 sensors. 

### DIFF
--- a/custom_components/ithodaalderop/config_flow.py
+++ b/custom_components/ithodaalderop/config_flow.py
@@ -135,6 +135,9 @@ class IthoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_rooms(self, user_input: Mapping[str, Any] | None = None):
         """Configure rooms for autotemp."""
         if user_input is not None:
+
+            for key, value in user_input.items():
+                user_input[key] = value.replace(" ", "_")
             self.config.update(user_input)
             if self.config[CONF_ADVANCED_CONFIG]:
                 return await self.async_step_advanced_config()
@@ -196,6 +199,9 @@ class IthoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_remotes(self, user_input: Mapping[str, Any] | None = None):
         """Configure up to 5 remotes."""
         if user_input is not None:
+            for key, value in user_input.items():
+                user_input[key] = value.replace(" ", "_")
+
             self.config.update(user_input)
             if self.config[CONF_ADVANCED_CONFIG]:
                 return await self.async_step_advanced_config()
@@ -297,6 +303,8 @@ class IthoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ):
         """Reconfigure rooms for autotemp."""
         if user_input is not None:
+            for key, value in user_input.items():
+                user_input[key] = value.replace(" ", "_")
             self.config.update(user_input)
             return self.async_update_reload_and_abort(
                 self.entry, data=self.config, reason="reconfigure_successful"
@@ -349,6 +357,9 @@ class IthoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ):
         """Reconfigure up to 5 remotes."""
         if user_input is not None:
+            for key, value in user_input.items():
+                user_input[key] = value.replace(" ", "_")
+
             self.config.update(user_input)
             return self.async_update_reload_and_abort(
                 self.entry, data=self.config, reason="reconfigure_successful"

--- a/custom_components/ithodaalderop/manifest.json
+++ b/custom_components/ithodaalderop/manifest.json
@@ -14,5 +14,5 @@
   "mqtt": ["ithohru/#"],
   "requirements": [
   ],
-  "version": "2.5.1-b1"
+  "version": "2.5.5"
 }

--- a/custom_components/ithodaalderop/sensors/autotemp.py
+++ b/custom_components/ithodaalderop/sensors/autotemp.py
@@ -100,7 +100,7 @@ def get_autotemp_sensors(config_entry: ConfigEntry):
     for x in range(1, 8):
         template_sensors = copy.deepcopy(list(AUTOTEMP_ROOM_SENSORS))
         room = config_entry.data["room" + str(x)]
-        if room not in ("", "Room " + str(x)):
+        if room not in ("", "Room_" + str(x)):
             for description in template_sensors:
                 description.json_field = description.json_field.replace("X", str(x))
                 description.topic = topic

--- a/custom_components/ithodaalderop/sensors/co2_remote.py
+++ b/custom_components/ithodaalderop/sensors/co2_remote.py
@@ -19,7 +19,7 @@ def get_co2_remote_sensors(config_entry: ConfigEntry):
     topic = get_mqtt_remote_topic(config_entry.data)
     for x in range(1, 5):
         remote = config_entry.data["remote" + str(x)]
-        if remote not in ("", "Remote " + str(x)):
+        if remote not in ("", "Remote_" + str(x)):
             description = copy.deepcopy(REMOTE_SENSOR_TEMPLATE)
             description.topic = topic
             description.json_field = remote


### PR DESCRIPTION
Fixes #140 by removing spaces in entity names.


Requires delete + re-add. Spaces are replaced with _