### PR TITLE
fix: handle 'not available' sentinel string from IthoWiFi firmware

### DIFF
--- a/custom_components/ithodaalderop/sensors/fan.py
+++ b/custom_components/ithodaalderop/sensors/fan.py
@@ -117,6 +117,12 @@ class IthoSensorFan(IthoBaseSensor):
             value = None
         else:
             value = payload[json_field]
+            # The IthoWiFi firmware emits the string "not available" as a
+            # sentinel for sensors with no current reading. HA's strict
+            # numeric sensor validation rejects strings, so map this to
+            # None so the entity becomes "unavailable" instead of raising.
+            if isinstance(value, str) and value == "not available":
+                value = None
             # HRU ECO 350
             if json_field == "Actual Mode":
                 self._extra_state_attributes = {"Code": value}


### PR DESCRIPTION
## Problem

The IthoWiFi firmware publishes the literal string `"not available"` in the `ithostatus` MQTT payload for sensor fields that currently have no reading. This is intentional firmware behaviour — fields like `RelativeHumidity`, `AirQuality (%)`, `BypassPos (%)`, `Indoor/Outdoor Temp/Humidity`, etc. are still emitted but with the sentinel value rather than being omitted.

When this integration creates an HA sensor with a numeric `device_class`/`state_class`/unit (e.g. `humidity` / `measurement` / `%`), HA's strict numeric validation rejects the string and raises `ValueError` on every MQTT update. On a CVE-Silent unit this can produce thousands of log occurrences per day, e.g.:

```
ValueError: Sensor sensor.itho_cve_relative_humidity has device class 'humidity',
state class 'measurement' unit '%' and suggested precision 'None' thus indicating
it has a numeric value; however, it has the non-numeric value: 'not available' (<class 'str'>)
```

The error originates from `custom_components/ithodaalderop/sensors/fan.py:207` (`self.async_write_ha_state()`).

## Fix

Right after reading the value from the JSON payload, map the sentinel string to `None`. HA renders `None` as "unavailable", which is the correct semantic when the firmware tells us there's no current reading. All the existing per-field branches downstream (`isinstance(value, (int, float))`, `str(value).isnumeric()`) already handle `None` correctly, so the change is additive — no value that was previously working changes behaviour.

```python
if isinstance(value, str) and value == "not available":
    value = None
```

## Scope

Only `sensors/fan.py` is touched here because that's the file in the user-reported traceback (subscribed to the firmware's `ithostatus` topic). The other sensor files in this integration (`autotemp.py`, `wpu.py`, `co2_remote.py`) follow the same `payload[json_field]` → `_attr_native_value` pattern and would benefit from the same guard if their respective firmware payloads ever emit the sentinel — happy to extend in a follow-up if you want it on the same PR.

## Disclosure

This patch was generated by Claude (Anthropic), reviewed and submitted by the IthoWiFi firmware author. The reproduction steps, traceback, and design rationale were validated against the firmware source ([generic_functions.cpp](https://github.com/arjenhiemstra/ithowifi/blob/master/software/NRG_itho_wifi/main/ithodevice/IthoStatus.cpp)).