### PR TITLE
Fix UnboundLocalError in IthoThermostatWPU.message_received (#149)

### DIFF
--- a/custom_components/ithodaalderop/sensors/wpu.py
+++ b/custom_components/ithodaalderop/sensors/wpu.py
@@ -104,15 +104,16 @@ class IthoThermostatWPU(IthoBaseSensor):
         """Handle new MQTT messages."""
         payload = json.loads(message.payload)
 
+        value = None
         if payload.get("ECO selected on thermostat", 0) == 1:
             value = "Eco"
-        if payload.get("Comfort selected on thermostat", 0) == 1:
+        elif payload.get("Comfort selected on thermostat", 0) == 1:
             value = "Comfort"
-        if payload.get("Boiler boost from thermostat", 0) == 1:
+        elif payload.get("Boiler boost from thermostat", 0) == 1:
             value = "Boost"
-        if payload.get("Boiler blocked from thermostat", 0) == 1:
+        elif payload.get("Boiler blocked from thermostat", 0) == 1:
             value = "Off"
-        if payload.get("Venting from thermostat", 0) == 1:
+        elif payload.get("Venting from thermostat", 0) == 1:
             value = "Venting"
 
         self._attr_native_value = value


### PR DESCRIPTION
Initialize `value` to None before the thermostat mode checks and convert the mutually-exclusive `if` statements to an `elif` chain. Previously, an ithostatus payload without any active thermostat mode key set to 1 left `value` unassigned, raising UnboundLocalError on the final assignment.