### PR TITLE
fix: keep last value on spurious 0/missing WPU meter reading (protect statistics)

### DIFF
--- a/custom_components/ithodaalderop/sensors/wpu.py
+++ b/custom_components/ithodaalderop/sensors/wpu.py
@@ -4,6 +4,7 @@ import copy
 import json
 
 from homeassistant.components import mqtt
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
@@ -76,7 +77,18 @@ class IthoSensorWPU(IthoBaseSensor):
         """Handle new MQTT messages."""
         payload = json.loads(message.payload)
         json_field = self.entity_description.json_field
+
+        is_total_increasing = (
+            self.entity_description.state_class == SensorStateClass.TOTAL_INCREASING
+        )
+
         if json_field not in payload:
+            # For a monotonically increasing meter a missing field is a partial
+            # MQTT publish, not a genuine reset to unknown. Dropping to None would
+            # make Home Assistant treat the next real value as a full counter
+            # reset, corrupting long-term statistics. Keep the last known value.
+            if is_total_increasing:
+                return
             value = None
         else:
             value = payload[json_field]
@@ -85,6 +97,23 @@ class IthoSensorWPU(IthoBaseSensor):
                     "Code": value,
                 }
                 value = WPU_STATUS.get(int(value), "Unknown status")
+            elif is_total_increasing:
+                # The WPU occasionally publishes a spurious 0 (or a value below
+                # the last reading) for its lifetime energy counters. These are
+                # glitches, not real resets, so ignore them and keep the last
+                # known value to avoid corrupting long-term statistics.
+                try:
+                    new_value = float(value)
+                except (TypeError, ValueError):
+                    return
+                if new_value == 0:
+                    return
+                if self._attr_native_value is not None:
+                    try:
+                        if new_value < float(self._attr_native_value):
+                            return
+                    except (TypeError, ValueError):
+                        pass
 
         self._attr_native_value = value
         self.async_write_ha_state()


### PR DESCRIPTION
The WPU `total_increasing` energy counters (`e_consumption_during_*`, `e_consumption_*`) occasionally receive either a **partial MQTT publish** (the energy field is absent from the JSON payload) or a **spurious `0`** from the device. 

In `IthoSensorWPU.message_received` these cases set the native value to `None` (→ `unknown`) or `0`. For a `total_increasing` sensor Home Assistant interprets that drop as a **counter reset**: the next valid reading is then recorded as a single huge delta, which corrupts the long-term statistics and the Energy Dashboard (you see one enormous spike, e.g. the full lifetime total counted as one hour of consumption).

### Fix
For `total_increasing` sensors only, `message_received` now keeps the last known value when:
- the JSON field is missing (partial publish),
- the incoming value is `0`,
- the incoming value is lower than the previous reading (a monotonic counter should never decrease).

All other sensors are unchanged — `0` and missing fields keep their existing behaviour, since `0` is a legitimate measurement value for temperatures, pressures, percentages, timers, etc.

### Impact
- No new entities, no config changes, no breaking changes.
- Passes `ruff check` and is `hassfest`-clean.
- Prevents the recurring Energy Dashboard / statistics corruption for WPU energy sensors.

Tested live on a real WPU (2.5.7): sensors load normally, no errors in the log, and glitch values are now ignored instead of resetting the counter.