### PR TITLE
Fix CO2 remote crash when remote has no CO2 info (#152)

### DIFF
--- a/custom_components/ithodaalderop/sensors/co2_remote.py
+++ b/custom_components/ithodaalderop/sensors/co2_remote.py
@@ -47,10 +47,12 @@ class IthoSensorCO2Remote(IthoBaseSensor):
         """Handle new MQTT messages."""
         payload = json.loads(message.payload)
         json_field = self.entity_description.json_field
-        if json_field not in payload:
-            value = None
+
+        remote_payload = payload.get(json_field)
+        if isinstance(remote_payload, dict):
+            value = remote_payload.get("co2")
         else:
-            value = payload[json_field]["co2"]
+            value = None
 
         self._attr_native_value = value
         self.async_write_ha_state()


### PR DESCRIPTION
Fixes #152

When a configured remote does not include CO2 data, the MQTT payload for that remote can be either `null` or a dict without a `co2` key (e.g. `{"remote0":null}` or `{"remote0":{"timestamp":0,...}}`). The previous code did `payload[json_field]["co2"]`, which raised `TypeError: 'NoneType' object is not subscriptable` or `KeyError: 'co2'`, spamming the Home Assistant log.

This change reads the remote payload with `.get()` and only extracts `co2` when it is a dict, falling back to `None` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)