### PR TITLE
Add status code 4 (Heat Recovery) for HRU ECO 250/300

### DIFF
--- a/custom_components/ithodaalderop/const.py
+++ b/custom_components/ithodaalderop/const.py
@@ -164,6 +164,7 @@ HRU_ECO_STATUS = {
 }
 
 HRU_ECO_250_300_STATUS = {
+    4: "Heat Recovery",
     5: "Heat Recovery",
     6: "Heat Recovery (Frost)",
     8: "Cooling Recovery",


### PR DESCRIPTION
### Problem

`HRU_ECO_250_300_STATUS` has no entry for code `4`, so a unit reporting it renders as `Unknown status`. On my HRU ECO 300 (unit fw 9, hw 10, add-on fw 3.3.0-beta2) code 4 is the **normal heat-recovery state** and is reported for hours at a time, which makes the status sensor unusable for a large part of the year. The raw value is preserved in the `Code` attribute, which is how I identified it.

### Evidence that 4 = Heat Recovery

1. **Itho ServiceTool.** A user reading the official ServiceTool on an HRU ECO 300 reported `4 = "Warmte terugwinning"` (heat recovery), alongside `8 = "Koelte terugwinning"` and `9 = "Zomer bypass"` — arjenhiemstra/ithowifi#97. Codes 8 and 9 already match this integration, which is a good consistency check on that source.
2. **A second unit.** #78 contains a December payload from another HRU ECO 300 with `"Status":4`, outside 12.5 °C, supply warmed to 20.2 °C against 20.8 °C extract — textbook heat recovery.
3. **40 days of my own logging.** Code 4 always coincides with the bypass closed and supply air being *warmed* against extract. Example, 2026-08-11: status 8 all afternoon → 9 (bypass open) at 18:00 → **4 from 19:30–21:15** as the evening cooled, during which the bypass closes and supply air rises from ~19 °C (outside) to 22 °C against 23.6 °C extract. Current live reading shows the same signature: outside 21.5 °C in, 22.0 °C to the house, 23.3 °C extract.

### Notes on scope

- **5 and 6 are deliberately untouched.** #118 reports `5 = HR_Mass` from the ServiceTool on another HRU 300, and my unit has never emitted 5 or 6 in 40 days. Rather than assume one supersedes the other, 4 and 5 simply map to the same user-facing label — that seems safest given the numbering may vary with unit firmware.
- **1, 2, 3 and 7 are left unmapped**, as I have no evidence for them and would rather they keep showing `Unknown status` than carry a guess.

This follows the same pattern as #120 and #137.